### PR TITLE
Link pull requests to release

### DIFF
--- a/src/handlers/release/published.js
+++ b/src/handlers/release/published.js
@@ -1,0 +1,37 @@
+// @flow
+
+import github from '../../github';
+import Logger from '../../logger';
+
+const { log } = new Logger('release/published.js');
+
+type ReleasePublishedPayload = {
+    release: {
+        body: string;
+        html_url: string;
+    },
+    repository: {
+        owner: { login: string; };
+        name: string;
+    }
+};
+
+export default function({ release, repository }: ReleasePublishedPayload) {
+    const { login: owner } = repository.owner;
+    const { name: repo } = repository;
+    const { body, html_url: releaseUrl } = release;
+
+    const msg = `Released in ${releaseUrl} :tada:`;
+
+    log('Linking pull requests to release', 'verbose');
+
+    const regex = /- \[#(\d+)]/g;
+
+    let match;
+
+    while ((match = regex.exec(body)) !== null) {
+        const issue = match[1];
+        log(`Add comment to /repos/${owner}/${repo}/issues/${issue}/comments`, 'verbose');
+        github.addIssueComment(issue, owner, repo, msg);
+    }
+}


### PR DESCRIPTION
Fixes #13.

![image](https://cloud.githubusercontent.com/assets/7579804/23594093/e01e5118-01cb-11e7-82f8-21fe19e9de0a.png)

It assumes that release notes link to pull requests with the format `- [#1234`. If I just looked for `[#1234` it would also add comments to issues, which we don't want?
