### PR TITLE
add triage label when an issue is opened

### DIFF
--- a/src/handlers/issues/opened.js
+++ b/src/handlers/issues/opened.js
@@ -32,7 +32,13 @@ export default function({ issue, repository }: OpenedIssuePayload) {
         };
 
         log(`User is not member of Babel org. Adding comment`, 'verbose');
-        return github.addIssueComment(issue.number, owner, repo, msg);
+        return github.addIssueComment(issue.number, owner, repo, msg)
+        .then(() => github.addLabels(
+            issue.number,
+            owner,
+            repo,
+            ['pending triage']
+        ));
     }).catch(e => {
         log(`Failed attempting to add new issue comment. Details: ${e.message}`);
     });


### PR DESCRIPTION
Ref https://github.com/babel/babel-bot/issues/14

- [ ] Need to remove the triage label when another triage issue label is added?

if someone wants to do that 👍 