### PR TITLE
Delete branch when merged

### DIFF
--- a/src/github.js
+++ b/src/github.js
@@ -91,3 +91,12 @@ exports.createIssueReaction = ({ content, number, owner, repo }: IssueParams) =>
         body: JSON.stringify({ content })
     }).then(({ body }) => body);
 }
+
+type DeleteBranchParams = {
+  owner: string;
+  repo: string;
+  branch: string;
+}
+exports.deleteBranch = ({ owner, repo, branch }: DeleteBranchParams) => {
+  return del(`/repos/${owner}/${repo}/git/refs/heads/${branch}`);
+}

--- a/src/handlers/pull_request/closed.js
+++ b/src/handlers/pull_request/closed.js
@@ -1,0 +1,38 @@
+// @flow
+
+import Logger from '../../logger';
+import github from '../../github';
+
+const { log } = new Logger('pull_request/closed.js');
+
+type ClosedPRPayload = {
+    number: number;
+    pull_request: {
+        merged: boolean;
+        head: {
+            ref: string;
+        }
+    };
+    repository: {
+        name: string;
+        owner: {
+            login: string;
+        }
+    };
+};
+
+export default function({ number, pull_request, repository }: ClosedPRPayload) {
+    const { merged, head: { ref: branch } } = pull_request;
+    const { name: repo, owner: { login: owner } } = repository
+
+    if (!merged) {
+        log(`Pull request #${number} was closed but not merged`, 'verbose');
+        return;
+    }
+
+    github.deleteBranch({
+        owner: owner,
+        repo: repo,
+        branch: branch
+    })
+}


### PR DESCRIPTION
Kind of trivial but sometimes we forget to delete branches after merging pull requests. This patch will automatically delete a branch when a pull request is **merged**. If it is only **closed**, it will not be deleted because someone might want to open a new pull request or whatever.