### PR TITLE
Fix REPL comments

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ insert_final_newline = true
 
 [{package.json}]
 indent_size = 2
+
+[*.js]
+indent_size = 2

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
   directories:
   - node_modules
 node_js:
-  - '4'
+  - '14'
 
 notifications:
   slack:

--- a/src/circleci.js
+++ b/src/circleci.js
@@ -40,6 +40,22 @@ export function parseBuildURL(buildURL: string): {
   return {owner, repo, build: +build};
 }
 
+/**
+ * Extract the CircleCI build URL from GitHub check run output summary
+ * @param {string} outputSummary
+ * @example
+ *
+ * extractBuildURL("* [build-standalone](https://circleci.com/gh/babel/babel/21115?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link) - Success")
+ * // returns "https://circleci.com/gh/babel/babel/21115?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link"
+ */
+export function extractBuildURL(outputSummary: string): string {
+  const matches = outputSummary.match(/\[build-standalone\]\(([^(]+)\)/);
+  if (!matches || !matches[1]) {
+    throw new Error(`Unsupported Check Run Output Summary: ${outputSummary}`);
+  }
+  return matches[1];
+}
+
 export async function fetchBuild(
   owner: string,
   repo: string,

--- a/src/handlers/check_run/completed.js
+++ b/src/handlers/check_run/completed.js
@@ -11,19 +11,24 @@ import * as circleci from '../../circleci';
 import github from '../../github';
 import Logger from '../../logger';
 import { replPreview } from '../../messages';
-import type { StatusPayload } from './types';
+import type { CheckRunPayload } from './types';
 
-const { log } = new Logger('status/success.js');
+const { log } = new Logger('check_run/completed.js');
 
-export default async function(payload: StatusPayload): Promise<void> {
+export default async function(payload: CheckRunPayload): Promise<void> {
   // We only care about CircleCI statuses
-  if (payload.context !== 'ci/circleci') {
-    log(`Ignoring payload ${payload.id} as it is not CircleCI: ${payload.context}`, 'verbose');
+  const { check_run } = payload;
+  if (check_run.name !== 'build-standalone') {
+    log(`Ignoring check run ${check_run.id} as it is not build-standalone checks: ${check_run.name}`, 'verbose');
     return;
   }
 
+  if (check_run.conclusion !== "success") {
+    log(`Ignoring check run ${payload.check_run.id} as it does not conclude successfully: ${check_run.conclusion}`, 'verbose');
+  }
+
   try {
-    const { owner, repo, build: buildNum } = circleci.parseBuildURL(payload.target_url);
+    const { owner, repo, build: buildNum } = circleci.parseBuildURL(circleci.extractBuildURL(check_run.output.summary));
 
     // GitHub don't give us the pull request URL, so we need to get that from
     // CircleCI's API.

--- a/src/handlers/check_run/completed.js
+++ b/src/handlers/check_run/completed.js
@@ -24,7 +24,7 @@ export default async function(payload: CheckRunPayload): Promise<void> {
   }
 
   if (check_run.conclusion !== "success") {
-    log(`Ignoring check run ${payload.check_run.id} as it does not conclude successfully: ${check_run.conclusion}`, 'verbose');
+    log(`Ignoring check run ${check_run.id} as it does not conclude successfully: ${check_run.conclusion}`, 'verbose');
     return;
   }
 

--- a/src/handlers/check_run/completed.js
+++ b/src/handlers/check_run/completed.js
@@ -25,6 +25,7 @@ export default async function(payload: CheckRunPayload): Promise<void> {
 
   if (check_run.conclusion !== "success") {
     log(`Ignoring check run ${payload.check_run.id} as it does not conclude successfully: ${check_run.conclusion}`, 'verbose');
+    return;
   }
 
   try {

--- a/src/handlers/check_run/types.js
+++ b/src/handlers/check_run/types.js
@@ -1,0 +1,11 @@
+export type CheckRunPayload = {
+    action: "completed" | "created" | "requested_action" | "rerequested",
+    check_run: {
+        id: number,
+        conclusion: "success" | "failure" | "neutral" | "cancelled" | "timed_out" | "action_required" | "stale" | null,
+        name: string,
+        output: {
+          summary: string
+        }
+    },
+}


### PR DESCRIPTION
After https://github.com/babel/babel/pull/10500 is merged, babel-bot no longer replies REPL build comments as is did in https://github.com/babel/babel/pull/10496#issuecomment-535318030. I guess it is because the `test262` is now always `pending`, so the `status: success` event is never emitted so `babel-bot` is not even triggered to do the comment things.

In this PR we use the `checkRunEvent` inspired from convo with @hzoo, now `babel-bot` will comment the REPL links after the `build-standalone` task is completed successfully, even if Travis builds errors. I think it is okay to have broken REPL builds since it is not meant to be accessed by general users.

Here is a real world `GET /checkRuns` API output [example](https://prettier.io/playground/#N4Igxg9gdgLgprEAuEwA6UAEm0gJYAmuSmAbAAwCsA7ABykCMVANBtrlBAXAPqHE4QAWQAiAc1IBFAEwALADYBNaTADKBAOoAWaaICqAZgDyIxQA99AXlyssg2XACGBHgGdZjgbjBaD5aQBGWgxwlAHkYNSUAGbSBgwAnAk00QFw0bSRCQF+tHAB0gQGNmyCcGbwAE5QjvJ8RMiC6Gi4AO4QlQDW0fIQrQC0-C3ILbgMpAEEpE7U-dKpDP1apI5w-QkG9P1wcOQBYTtw1NHRoyCsw45gMB2DRMNIZwyUzgmOBmD9BowGS5TSCXWV0BzyigWipFotGWZwAviU7LgAK6VeReECyGAwAAOriQAHp8Y5sXgAHRiPAwWRIgKkyAAW3xlTg2IgrnxAUcaXkHK5cB5YAcYE6-UqSKg7IoNHoTEoCPYGJg9LqKLRjVwmJxeMJFKpNLpEEZnO5vJNYol+KldEYVHlgm4MEceHkrh4qvRmtxBPxYDwlTA8jgvoNjPaXR6fVF4vx40m00cs3mAUWy1W602pG2u32aR2x2iAH4kUqeGBHPTsU6xFBLAA3MCuQawOBiSqOGB4aD9eR4KCdABkxfpPHpcAIeCR9MszOicEqbfkg5LrggKLAcEsuupAX6gqDnUbPb7dtwrkdMCRrnRDOxgfgDVsCsgUADl87UHRriRYHXriv51KU9HUqe8eHbdFpH8ch+nILQ5gYAAVcYkHiJBpFoAAtE9wENW84FA8D1RASDIJguDpEQ5CDAMJByAYLCAMREBVxxYsBHQOwFQ7GBA3RDQOm6XpWhIAIkWdAh+jPRwoAIWpoDgO0FS-el6UcSoAE90QAKkwABtUTxMkx0ZLkqA4AAXQACk9bUfT9AMgzJBl8TEWRTX5dyeQohhniLEsywrKsa3rRte3gVt23fbtewHIcRzHCcpxnOcFyXYcVzXDctxpXchQPaK+wASkwfpMFUb9f3-R9sEEeAKgEKAkXkeRqoVaTOHPd9XUgcUYAEchWsEdqIE66BXXdIibO9YkyWy2lnOZVl2WNDyVoFPKowtK0ZSoIkoA6yKxtwUpYWqjhywUoiDPkCSpJM3ozOwvdhTcMT4HY0oFX4RpGEoBItEoUhIJOs6QGJbEPs4wRvpIBhaHIOjBtPeQkTEa97MDX1cv3KrPsEThuHqdFRCEKQAA0ACFWiEBCxGpkQAFFrEYmrBD6MzKkh1mFV6CkPyI31-UxvBFJq3AYcwBg4jh6gBrxhUCd4CXcFEBn1KMToEnUjDpAAMSRRwyexWQCAAcXkWsAgAKzVoQAC8Ga0AA5O2AEFmcGtra3bNS3VRD0sS9QlHG94DXGkclKW3S852feBYBDfEkRjaXaFlgta0sLRRYVCLQ995WQBzwQJpIDVA9smbI71ebDST1w53ZQWHN9Yvy+VP21TLxUtW9ObE+b4W25AaIIGavpG87gPe+Dklq+3ROY8qJuMcc-FR-H1pG+HjehN7MQp8mivprn-vnKXlehbX3e+n34B8RGhxKjdBvKnhFnudwCkz3G-2j5nokp8o76nPq-S+Lc8AuTwD-e+38YD1Hfp7QQUl5xjkPt3Kas9ZrANroyC+dkr6+nxCg5kBB77sznLCe+i0ICIPlsgmkrgwCVDwNiDsY10H2GPlg+eIC674MHmvL8AQmEsLYV1YeHQxDSTwHbQ6EpOHlwAVXM+-CwEEIgQ-SoYhcZQwVDQ3+XcuHKKATXRe6jBFEIMcPOAtYEAwEMdPIOgDsFmNAY3DRwt8S2Psa4e+2IWHezAOpOhejBDMnXHgOxLgfGwEcf-ZxKicHmI8ZYyBES4BRLQbEhxw8YDqWxJdbuRhtEyLkew-mSDTyUl4M4ekvYBDRFqA3PGp08bnVHOiAAwqvLpABJTAXS8q6NZrgbgojWEVPRKoHYmAqRwEwFJC8rhMAQGiJgdSq5KiDN6QMsMgk+grPFNwbZ8zMAAAUmryEwAAJTgAARyRHAM8gzhlzK5JgXscyHCYFNpSAAEjSTAeg+mkkwBoKOmBnoHkwAgLkgYCDMEwBfTArRnTXM4K0TAaRMDwoWTcTAYgIBzOJWcoZON3kBE+VgP5MBAVUoJbWPAcAsVnOiFczAshmVtn9LIdSuKZKLPPJeVZ6yelX36disSN1XCkhaJzDA8qWhQC0k7EacAdKlUUKuKFw0YCwpqAEQMvyAVAvJcKFZo9tniocpK6IlRDTfIWbS+lwK+lIs2UiTA9JLz6t5tSglNrAySukgQA1eKoVvKtRsrZqzSlQFkfIsF2qvU+peR4OxuKCD1KwAEqJzoWzPMwNGz12ypFlPkSS8NRqFnQtlaLXA5Qqg1BVH-DB3DPGORDA2xUHdS7GOcaoxk4NwHC2xhantzCnAET6kRSCcMYKAmkFoBCFE0LkFopQBiSMQBImxLJGdEE6K0H6EwU91AkKUCQFoBItFqDbvaSAQplR6l-gkY0Di3NBB1vRK0Fh70P6jJAKOR0B7PBEWZM4Yerh96Bh4NEAt6JIMNFaTunJ-4SC6Xod4PKPBzTD2ha9Gpx0obmRBoBJ9Vy8MPKeT-AQWGPx2DI1AeEUBzjMXEWNZAoA1IOtaOctSCBXDIDBvIVojh1LCeYCAAIbZhT4VUJWX0UAxDIBgGKOA0nMTKg0Fy+ArglNwBmRKSk+b8kiYbFJ-AEo5wwHOW2MQqlkBNJdJpkAVtXBmApnJzoCmLoABlexwGc80tzHmzCqFg3ASQSJ1Uhdc9Jysy85wiY89AdjebYAQoIFSZA8NEsOobhoNs2IRMBOeXOOx7HHnqvsxAXEInHCNjMmOMc7HmSPL9HAezjhHOOHiw3aTDd6lqY00NqLMW4tIBc4NkAjoAjZdy2haT6mnRHjEF0w0TmUDPMoOxmOCEuTCem6F6TtYnl9JkvY1QzDJmuxkqofJgYBtwFhLCIAA) generated by
```
curl -i -H "Accept: application/vnd.github.antiope-preview+json" "https://api.github.com/repos/babel/babel/check-runs/605786105" | pbcopy
```

which is also the payload of [`checkRunEvent`](https://developer.github.com/v3/activity/events/types/#checkrunevent)

Disclaimer: I didn't test against the real repo, let's pray I will not break the repo.

/cc gang @nicolo-ribaudo @hzoo @existentialism @kaicataldo 